### PR TITLE
added support for cas, diaries, friend praise, slayer tasks and quests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # OSRS clicker training
-A clicker sound to greet you when you've leveled up! Good doggy!
+
+## Good doggy!
+A clicker sound to greet you when you've leveled up, completed quests, achievement diaries, combat achievements and more!
 Thanks to https://github.com/daanbom/Custom-Drop-Sounds for audio playing code, and https://github.com/jurrejelle/BloodShardNotifier for plugin logic

--- a/src/main/java/com/pyonium/clicker/ClickerConfig.java
+++ b/src/main/java/com/pyonium/clicker/ClickerConfig.java
@@ -123,15 +123,83 @@ public interface ClickerConfig extends Config
         return 10000;
     }
 
+    @ConfigSection(
+            name = "Other clicks",
+            description = "Settings for other possible click triggers",
+            position = 50
+    )
+    String OTHERCLICKS = "OtherClicks";
+
     @ConfigItem(
+            section = OTHERCLICKS,
             keyName = "onClog",
             name = "Click On Collection Log",
             description = "Rewards Collection Log Slots",
-            position=50
+            position=51
     )
     default boolean onClog()
     {
         return true;
+    }
+
+    @ConfigItem(
+            section = OTHERCLICKS,
+            keyName = "onQuest",
+            name = "Click On Quest",
+            description = "Rewards Quest Completion",
+            position=52
+    )
+    default boolean onQuest()
+    {
+        return false;
+    }
+
+    @ConfigItem(
+            section = OTHERCLICKS,
+            keyName = "onDiary",
+            name = "Click On Achievement Diary Step",
+            description = "Rewards Achievement Diary Step Completion",
+            position=53
+    )
+    default boolean onDiary()
+    {
+        return false;
+    }
+
+    @ConfigItem(
+            section = OTHERCLICKS,
+            keyName = "onCombatTask",
+            name = "Click On Combat Achievement",
+            description = "Rewards Combat Achievement Completion",
+            position=54
+    )
+    default boolean onCombatTask()
+    {
+        return false;
+    }
+
+    @ConfigItem(
+            section = OTHERCLICKS,
+            keyName = "onSlayerTask",
+            name = "Click On Slayer Task",
+            description = "Rewards Slayer Task Completion",
+            position=55
+    )
+    default boolean onSlayerTask()
+    {
+        return false;
+    }
+
+    @ConfigItem(
+            section = OTHERCLICKS,
+            keyName = "onFriendPraise",
+            name = "Click On Friend Praise",
+            description = "Rewards Praise From Friends In Public Chat",
+            position=56
+    )
+    default boolean onFriendPraise()
+    {
+        return false;
     }
 
 

--- a/src/main/java/com/pyonium/clicker/ClickerPlugin.java
+++ b/src/main/java/com/pyonium/clicker/ClickerPlugin.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.StatChanged;
+import net.runelite.api.events.OverheadTextChanged;
 import net.runelite.client.audio.AudioPlayer;
 import net.runelite.client.chat.ChatColorType;
 import net.runelite.client.chat.ChatMessageBuilder;
@@ -58,8 +59,11 @@ public class ClickerPlugin extends Plugin
 			CLICKER_SOUND_FILE
 	};
 
-
 	private static final Pattern COLLECTION_LOG_ITEM_REGEX = Pattern.compile("New item added to your collection log:.*");
+    private static final Pattern SLAYER_TASK_REGEX = Pattern.compile("You have completed your task! You killed .*. You gained .*");
+    private static final Pattern COMBAT_TASK_REGEX = Pattern.compile("Congratulations, you've completed a .* combat task: .*");
+    private static final Pattern QUEST_REGEX = Pattern.compile("Congratulations, you've completed a quest: .*");
+    private static final Pattern DIARY_REGEX = Pattern.compile("Well done! You have completed a.* task in the .* area. Your Achievement Diary has been updated.");
 
 	private ClickerSession session;
 
@@ -77,8 +81,13 @@ public class ClickerPlugin extends Plugin
 	//interval mode
 	private int absoluteInterval;
 
-	//misc
+	//other
 	private boolean onClog;
+    private boolean onCombatTask;
+    private boolean onSlayerTask;
+    private boolean onQuest;
+    private boolean onFriendPraise;
+    private boolean onDiary;
 
 	@Override
 	protected void startUp()
@@ -99,6 +108,11 @@ public class ClickerPlugin extends Plugin
 		this.absoluteInterval = config.absoluteInterval();
 
 		this.onClog = config.onClog();
+        this.onCombatTask = config.onCombatTask();
+        this.onSlayerTask = config.onSlayerTask();
+        this.onQuest = config.onQuest();
+        this.onFriendPraise = config.onFriendPraise();
+        this.onDiary = config.onDiary();
 	}
 
 	@Override
@@ -204,10 +218,6 @@ public class ClickerPlugin extends Plugin
 	@Subscribe
 	public void onChatMessage(ChatMessage chatMessage)
 	{
-		if(!onClog)
-		{
-			return;
-		}
 		ChatMessageType msgType = chatMessage.getType();
 		if(!msgType.equals(ChatMessageType.GAMEMESSAGE))
 		{
@@ -215,12 +225,53 @@ public class ClickerPlugin extends Plugin
 		}
 
 		String outputMessage = Text.removeTags(chatMessage.getMessage());
-		if(COLLECTION_LOG_ITEM_REGEX.matcher(outputMessage).matches())
+		if(COLLECTION_LOG_ITEM_REGEX.matcher(outputMessage).matches() && onClog)
 		{
 			sendHighlightedMessage("A new item in your collection log! " + praise);
 			playSound(CLICKER_SOUND_FILE);
 		}
+        if(SLAYER_TASK_REGEX.matcher(outputMessage).matches() && onSlayerTask)
+        {
+            sendHighlightedMessage("Slayer task complete! " + praise);
+            playSound(CLICKER_SOUND_FILE);
+        }
+        if(COMBAT_TASK_REGEX.matcher(outputMessage).matches() && onCombatTask)
+        {
+            sendHighlightedMessage("Combat Achievement complete! " + praise);
+            playSound(CLICKER_SOUND_FILE);
+        }
+        if(QUEST_REGEX.matcher(outputMessage).matches() && onQuest)
+        {
+            sendHighlightedMessage("Quest complete! " + praise);
+            playSound(CLICKER_SOUND_FILE);
+        }
+        if(DIARY_REGEX.matcher(outputMessage).matches() && onDiary)
+        {
+            sendHighlightedMessage("Diary task complete! " + praise);
+            playSound(CLICKER_SOUND_FILE);
+        }
 	}
+
+    @Subscribe
+    public void onOverheadTextChanged(OverheadTextChanged overheadTextChanged)
+    {
+        if (!onFriendPraise)
+        {
+            return;
+        }
+
+        //Check the user is on the friends list
+        Actor actor = overheadTextChanged.getActor();
+        if (actor instanceof Player)
+        {
+            Player player = (Player) actor;
+            if (overheadTextChanged.getOverheadText().matches(praise) && player.isFriend())
+            {
+                playSound(CLICKER_SOUND_FILE);
+            }
+        }
+    }
+
 
 	private void playSound(File f)
 	{
@@ -261,6 +312,11 @@ public class ClickerPlugin extends Plugin
 		this.absoluteInterval = config.absoluteInterval();
 
 		this.onClog = config.onClog();
+        this.onCombatTask = config.onCombatTask();
+        this.onSlayerTask = config.onSlayerTask();
+        this.onQuest = config.onQuest();
+        this.onFriendPraise = config.onFriendPraise();
+        this.onDiary = config.onDiary();
 	}
 
 	private void sendHighlightedMessage(String message) {


### PR DESCRIPTION
Added an option to allow clicks when
- quests are completed
- combat achievements are completed
- slayer tasks are completed
- achievement tasks are completed
- players on your friend's list say your exact praise message in public chat (>///<)